### PR TITLE
Allow dots in migration names

### DIFF
--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -73,7 +73,7 @@ module HealthCheck
     def self.get_migration_version(dir = self.db_migrate_path)
       latest_migration = nil
       Dir[File.join(dir, "[0-9]*_*.rb")].each do |f|
-        l = f.scan(/0*([0-9]+)_[_a-zA-Z0-9]*.rb/).first.first
+        l = f.scan(/0*([0-9]+)_[_.a-zA-Z0-9]*.rb/).first.first
         latest_migration = l if !latest_migration || l.to_i > latest_migration.to_i
       end
       latest_migration

--- a/test/migrate/twelve/011_create_roles.roles.rb
+++ b/test/migrate/twelve/011_create_roles.roles.rb
@@ -1,0 +1,11 @@
+class CreateRoles < ActiveRecord::Migration
+  def self.up
+    create_table :roles do |t|
+      t.column :name, :string
+    end
+  end
+
+  def self.down
+    drop_table :roles
+  end
+end


### PR DESCRIPTION
Added the dot (.) as an allowed character in database migration name regex.
Background: simple_roles gem creates migrations with names like
create_user_roles.simple_roles.rb. Health check was raising a
NoMethodError on such migration files.
Existing test suite was failing as well, passed with the fix in place.
