### PR TITLE
Allow customization of standard checks run on /health_check

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -100,6 +100,9 @@ To change the configuration of health_check, create a file `config/initializers/
 
       config.http_status_for_error_object = 500
 
+      # You can customize which checks happen on a standard health check
+      config.standard_checks = [ 'database', 'migrations', 'custom' ]
+
       # You can set what tests are run with the 'full' or 'all' parameter
       config.full_checks = ['database', 'migrations', 'custom', 'email', 'cache']
 

--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -28,8 +28,10 @@ module HealthCheck
   # Array of custom check blocks
   mattr_accessor :custom_checks
   mattr_accessor :full_checks
+  mattr_accessor :standard_checks
   self.custom_checks = [ ]
   self.full_checks = ['database', 'migrations', 'custom', 'email', 'cache']
+  self.standard_checks = [ 'database', 'migrations', 'custom' ]
 
   def self.add_custom_check(&block)
     custom_checks << block

--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -46,7 +46,7 @@ module HealthCheck
           when 'cache'
             errors << HealthCheck::Utils.check_cache
           when "standard"
-            errors << HealthCheck::Utils.process_checks("database_migrations_custom")
+            errors << HealthCheck::Utils.process_checks(HealthCheck.standard_checks.join('_'))
             errors << HealthCheck::Utils.process_checks("email") unless HealthCheck::Utils.default_action_mailer_configuration?
           when "custom"
             HealthCheck.custom_checks.each do |custom_check|


### PR DESCRIPTION
Previously the standard checks were hard coded inside of the utils
checker. The specific use case was an interest in disabling the
migrations check by default, so that instances would not be kicked out
of the load balancer if the migration version was different. Obviously
that may not be what everyone wants, so this allows easy customization.
