### PR TITLE
Disable email check if standard check is overriden

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -31,12 +31,12 @@ module HealthCheck
   mattr_accessor :standard_checks
   self.custom_checks = [ ]
   self.full_checks = ['database', 'migrations', 'custom', 'email', 'cache']
-  self.standard_checks = [ 'database', 'migrations', 'custom' ]
+  self.standard_checks = [ 'database', 'migrations', 'custom', 'emailconf' ]
 
   def self.add_custom_check(&block)
     custom_checks << block
   end
-  
+
   def self.setup
     yield self
   end

--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -28,6 +28,8 @@ module HealthCheck
             HealthCheck::Utils.get_database_version
           when "email"
             errors << HealthCheck::Utils.check_email
+          when "emailconf"
+            errors << HealthCheck::Utils.check_email if HealthCheck::Utils.mailer_configured?
           when "migrations", "migration"
             if defined?(ActiveRecord::Migration) and ActiveRecord::Migration.respond_to?(:check_pending!)
               # Rails 4+
@@ -47,7 +49,6 @@ module HealthCheck
             errors << HealthCheck::Utils.check_cache
           when "standard"
             errors << HealthCheck::Utils.process_checks(HealthCheck.standard_checks.join('_'))
-            errors << HealthCheck::Utils.process_checks("email") if HealthCheck::Utils.mailer_configured?
           when "custom"
             HealthCheck.custom_checks.each do |custom_check|
               errors << custom_check.call(self)


### PR DESCRIPTION
Fixes #16 

Hi Ian, thanks for evaluating this pull request.

We recently ran into this issue where our health check returned not healthy on our email connectivity  even though we thought email checking was disabled with the line `config.standard_checks = [ 'database']`, since it doesn't include any email checks on it.

Please consider this pull request as a way to fix it, and please let me know if I can help with anything else.

Many thanks!