### PR TITLE
Fix to always return a 200 status code on success rather than 304.

### DIFF
--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -12,8 +12,9 @@ module HealthCheck
         errors = HealthCheck::Utils.process_checks(checks)
       rescue Exception => e
         errors = e.message
-      end     
+      end
       if errors.blank?
+        response.headers['Last-Modified'] = Time.now.httpdate
         obj = { :healthy => true, :message => HealthCheck.success }
         respond_to do |format|
           format.html { render :text => HealthCheck.success, :content_type => 'text/plain' }


### PR DESCRIPTION
@ianheggie

An initial request to /health_check receives a response with a 200 status code:

![screen shot 2015-07-05 at 11 36 51 am](https://cloud.githubusercontent.com/assets/1322709/8512868/1867b2e0-230b-11e5-8056-157c3165cd54.png)

Subsequent requests to /health_check receive responses with a 304 status code:

![screen shot 2015-07-05 at 11 37 01 am](https://cloud.githubusercontent.com/assets/1322709/8512869/1dfb7624-230b-11e5-902d-93336882368b.png)

This appears to be occuring because the response is 'success' for each request and is therefore not modified (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).

My application is integrating with a service that expects a 200 status code on success. This commit ensures that happens.

Do you think this is a behavior that others would find it helpful for the health_check gem to have?