### PR TITLE
Fix auto-magical addition of health_check/ route to app.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ if defined?(HealthCheck::Engine)
   unless HealthCheck::Engine.routes_already_defined
     # Ifmountable use: HealthCheck::Engine.routes.draw do
     Rails.application.routes.draw do
-      health_check_routes()
+      health_check_routes(nil, false)
     end
   end
 end

--- a/lib/health_check/health_check_routes.rb
+++ b/lib/health_check/health_check_routes.rb
@@ -2,8 +2,8 @@ if defined?(HealthCheck::Engine)
 
   module ActionDispatch::Routing
     class Mapper
-      def health_check_routes(prefix = nil)
-        HealthCheck::Engine.routes_already_defined ||= true
+      def health_check_routes(prefix = nil, manually_added=true)
+        HealthCheck::Engine.routes_already_defined ||= manually_added
         get "#{prefix || 'health_check'}(/:checks)(.:format)", :to => 'health_check/health_check#index'
       end
     end


### PR DESCRIPTION
After updating from 1.5.1 to 2.1 we've discovered that the auto-magically added route of /health_check/:checks is no longer available in production.  I'm not sure why this is only affecting rails apps in production mode, but I believe it is due to HealthCheck::Engine.routes_already_defined beings set to true unconditionally, instead of being set to false from the route addition in config/routes.rb.

Calling health_check_routes from our apps' config/routes.rb adds the route back in, but it would be nice to not have to call that.

I couldn't get any of the test system to work locally, but I've confirmed this commit fixes the issue.