### PR TITLE
Use `before_action` instead of `before_filter`

### DIFF
--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -5,7 +5,7 @@ module HealthCheck
   class HealthCheckController < ActionController::Base
 
     layout false if self.respond_to? :layout
-    before_filter :authenticate
+    before_action :authenticate
 
     def index
       last_modified = Time.now.utc


### PR DESCRIPTION
We should use `before_action` instead of `before_filter` in Rails v4.0 or later.