### PR TITLE
Use Bundler 1.12 temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ notifications:
 before_install:
   - gem update --system $RUBYGEMS_VERSION
   - gem --version
-  - gem install bundler
+  # Temporary version lock until Bundler >= 1.13.2
+  # https://github.com/bundler/bundler/issues/4975
+  - gem install bundler -v 1.12
   - bundle --version
   - mkdir -p tmp/bundle
 


### PR DESCRIPTION
This should hopefully prevent the build from breaking due to https://github.com/bundler/bundler/issues/4975, while waiting for Bundler 1.13.2 or higher to be released.

Fingers crossed. :)