### PR TITLE
Fixing NameError on `basic_auth_username`.

### DIFF
--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -13,7 +13,7 @@ module HealthCheck
       if max_age > 1
         last_modified = Time.at((last_modified.to_f / max_age).floor * max_age).utc
       end
-      public = (max_age > 1) && ! basic_auth_username
+      public = (max_age > 1) && ! HealthCheck.basic_auth_username
       if stale?(:last_modified => last_modified, :public => public)
         # Rails 4.0 doesn't have :plain, but it is deprecated later on
         plain_key = Rails.version < '4.1' ? :text : :plain


### PR DESCRIPTION
An error is raised when `max_age` is > 1:

```
NameError (undefined local variable or method `basic_auth_username' for #<HealthCheck::HealthCheckController:0x007f9b01d94510>):
  health_check (2.4.0) lib/health_check/health_check_controller.rb:16:in `index'
```