### PR TITLE
Add ability to check health of redis when url is non-standard redis url

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -138,6 +138,9 @@ To change the configuration of health_check, create a file `config/initializers/
 
       # http status code used when the ip is not allowed for the request
       config.http_status_for_ip_whitelist_error = 403
+
+      # When redis url is non-standard
+      config.redis_url = 'redis_url'
     end
 
 You may call add_custom_check multiple times with different tests. These tests will be included in the default list ("standard").

--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -63,6 +63,10 @@ module HealthCheck
 
   mattr_accessor :installed_as_middleware
 
+  # Allow non-standard redis url
+  mattr_accessor :redis_url
+  self.redis_url = 'redis://localhost:6379/0'
+
   def self.add_custom_check(name = 'custom', &block)
     custom_checks[name] ||= [ ]
     custom_checks[name] << block

--- a/lib/health_check/redis_health_check.rb
+++ b/lib/health_check/redis_health_check.rb
@@ -6,7 +6,7 @@ module HealthCheck
       unless defined?(::Redis)
         raise "Wrong configuration. Missing 'redis' gem"
       end
-      res = ::Redis.new.ping
+      res = ::Redis.new(url: HealthCheck.redis_url).ping
       res == 'PONG' ? '' : "Redis.ping returned #{res.inspect} instead of PONG"
     rescue Exception => e
       create_error 'redis', e.message


### PR DESCRIPTION
A non standard url is being used for a rails project I'm working on `redis://localhost:16379/0`. But the gem only checks for the url `redis://localhost:6379/0` (Note: ports are different). This pull request will allow to configure redis_url in the config but defaults to the standard url.