### PR TITLE
Properly fallback Redis URL

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -65,7 +65,7 @@ module HealthCheck
 
   # Allow non-standard redis url
   mattr_accessor :redis_url
-  self.redis_url = 'redis://localhost:6379/0'
+  self.redis_url = nil
 
   def self.add_custom_check(name = 'custom', &block)
     custom_checks[name] ||= [ ]


### PR DESCRIPTION
The recent version accidentally introduced a breaking change for those who uses `ENV["REDIS_URL"]` to set up Redis connection.

According to redis-rb's documentation:
> By default, the client will try to read the REDIS_URL environment variable and use that as URL to connect to. 

You can also find related [source code here](https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L9).