### PR TITLE
Default HealthCheck#redis_url to ENV['REDIS_URL']

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -65,7 +65,7 @@ module HealthCheck
 
   # Allow non-standard redis url
   mattr_accessor :redis_url
-  self.redis_url = 'redis://localhost:6379/0'
+  self.redis_url = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def self.add_custom_check(name = 'custom', &block)
     custom_checks[name] ||= [ ]


### PR DESCRIPTION
Fix regression introduced by #65 

From the `redis` gem:
> By default, the client will try to read the REDIS_URL environment variable and use that as URL to connect to.

All our projects are using non standard redis URL configured via `REDIS_URL` (which is also picked up by sidekiq). Since the upgrade to 2.7.0, the healthcheck are failing as `HealthCheck.redis_url` is defaulting to localhost.

