### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/health_check.gemspec
+++ b/health_check.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = [ "README.rdoc" ]
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 1.9.3'
-  gem.add_dependency(%q<rails>, [">= 4.0"])
+  gem.add_dependency(%q<railties>, [">= 4.0"])
   gem.add_development_dependency(%q<rake>, [">= 0.8.3"])
   gem.add_development_dependency(%q<shoulda>, ["~> 2.11.0"])
   gem.add_development_dependency(%q<bundler>, ["~> 1.2"])


### PR DESCRIPTION
Depending on rails prohibits developers from limiting the bundle
dependencies, resulting in larger deployment packages than are required.

If railties is used instead, removing dependencies likes sprockets,
actioncable, actionmailer, actionview, etc is possible.  Rails 5 is a
primary example of that kind of installation.