### PR TITLE
S3 should not depend on Rails secrets file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ test/bin/
 railsapps/
 test/*.gemfile.lock
 ,*
+.vagrant
+ubuntu*console.log
 
 # See: https://gist.github.com/ianheggie/9327010
 # for Global git ignore for OS/IDE/temp/backup files

--- a/README.rdoc
+++ b/README.rdoc
@@ -275,9 +275,11 @@ Last-modified is set to the current time (rounded down to a multiple of max_age 
 
 === Manual testing
 
-The instructions have been changed to using a vagrant virtual box for consistant results.
+The instructions have been changed to using a vagrant virtual box for consistent results.
 
-Install vagrant 1.9.7 or later and virtual_box or other local virtual machine providor.
+Install vagrant 1.9.7 or later and virtual_box or other local virtual machine provider.  Add the vagrant plugin called vbguest.
+
+    vagrant plugin install vagrant-vbguest
 
 Create a temp directory for throw away testing, and clone the health_check gem into it
 

--- a/lib/health_check/s3_health_check.rb
+++ b/lib/health_check/s3_health_check.rb
@@ -27,19 +27,14 @@ module HealthCheck
 
       private
 
+      # We already assume you are using Rails.  Let's also assume you have an initializer
+      # created for your Aws config.  We will set the region here so you can use an
+      # instance profile and simply set the region in your environment.
       def configure_client
-        return unless defined?(Rails)
+        ::Aws.config[:s3] = { force_path_style: true }
+        ::Aws.config[:region] ||= ENV['AWS_REGION'] || ENV['DEFAULT_AWS_REGION']
 
-        aws_configuration = {
-          region: Rails.application.secrets.aws_default_region,
-          credentials: ::Aws::Credentials.new(
-            Rails.application.secrets.aws_access_key_id,
-            Rails.application.secrets.aws_secret_access_key
-          ),
-          force_path_style: true
-        }
-
-        ::Aws::S3::Client.new aws_configuration
+        ::Aws::S3::Client.new
       end
 
       def aws_s3_client

--- a/test/provision_vagrant
+++ b/test/provision_vagrant
@@ -12,12 +12,12 @@ id
 pwd
 export DEBIAN_FRONTEND=noninteractive
 find /tmp/got-apt-update -mtime -1 || ( apt-get update && touch /tmp/got-apt-update )
-apt install --yes --force-yes -q build-essential ruby ruby-dev sqlite3 libsqlite3-dev nodejs
+apt install --yes --force-yes -q build-essential ruby ruby-dev sqlite3 libsqlite3-dev nodejs zlib1g-dev libffi-dev libssl-dev libreadline-dev
 
 (
   echo Install chruby
   [ -s chruby-0.3.9.tar.gz ] || wget -q -O chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
-  [ chruby-0.3.9 ] || tar -xzf chruby-0.3.9.tar.gz
+  [ -d chruby-0.3.9 ] || tar -xzf chruby-0.3.9.tar.gz
   cd chruby-0.3.9/
   ./scripts/setup.sh
   cat > /etc/profile.d/chruby.sh <<'EOF'
@@ -33,16 +33,16 @@ EOF
   which ruby-build || PREFIX=/usr/local ./ruby-build/install.sh
 
   mkdir -p /opt/rubies
-  [ -x /opt/rubies/1.9.3-p551/bin/bundle ] || ( ruby-build 1.9.3-p551 /opt/rubies/1.9.3-p551 && /opt/rubies/1.9.3-p551/bin/gem install bundler )
+  [ -x /opt/rubies/1.9.3-p551/bin/bundle ] || ( ruby-build 1.9.3-p551 /opt/rubies/1.9.3-p551 && /opt/rubies/1.9.3-p551/bin/gem install bundler smarter_bundler )
 
-  for v in 2.2.0
+  for v in 2.4.4
   do
-    [ -x /opt/rubies/$v/bin/bundle ] || ( ruby-build $v /opt/rubies/$v && /opt/rubies/$v/bin/gem install bundler )
+    [ -x /opt/rubies/$v/bin/bundle ] || ( ruby-build $v /opt/rubies/$v && /opt/rubies/$v/bin/gem install bundler smarter_bundler )
   done
 )
 
 echo Setup system ruby
-which bundle || gem install bundler 
+which bundle || gem install bundler smarter_bundler
 bundle --version
 set +x
 cat <<EOF


### PR DESCRIPTION
This will address https://github.com/ianheggie/health_check/issues/62.  It passed all tests but there is no test for S3 so I made sure to test it on a live system.

I don't believe the use of secrets.yml is common way to configure Aws in Rails applications.  Initializers seem to be best practice.  Here is a simple example of `config/initializers/aws.rb`:

```ruby
if ENV['AWS_ACCESS_KEY'].nil?
  Aws.config.update({
    region: ENV['AWS_REGION'] || 'us-west-2'
  })
else
  Aws.config.update({
    region: ENV['AWS_REGION'] || 'us-west-2',
    credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY'], ENV['AWS_SECRET_ACCESS_KEY']),
  })
end
```

If AWS_ACCESS_KEY is not set, we expect to use an instance profile.  With an instance profile, setting region is the minimum configuration you need.

Also included:
* Update provision_vagrant script to work with latest ubuntu/xenial64 (it takes 10 minutes for `vagrant up` on my laptop)
* Update documentation to indicate the need for Vagrant plugin vbguest