### PR TITLE
Fix broken Cache-Control headers

### DIFF
--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -23,7 +23,7 @@ module HealthCheck
         rescue Exception => e
           errors = e.message.blank? ? e.class.to_s : e.message.to_s
         end
-        response.headers['Cache-control'] = (public ? 'public' : 'private') + ', no-cache, must-revalidate' + (max_age > 0 ? ", max-age=#{max_age}" : '')
+        response.headers['Cache-Control'] = "must-revalidate, max-age=#{max_age}"
         if errors.blank?
           send_response true, nil, :ok, :ok
         else


### PR DESCRIPTION
Currently the Cache-Control header sent by the health_check gem will either be "Cache-Control: max-age=0, private, must-revalidate" (max_age 0, 1) or "Cache-Control: public" (max_age > 1).

This causes caching problems, since the max_age setting is ignored.

The problem is caused by wrong case and conflicting keywords when setting the cache header.

The "public" or "private" keyword will be set by the stale? block and
merged with the remaining Cache-Control header.

We also cannot set no-cache, since it negates the meaning of private /
public and also causes rails to throw away everything else in the
Cache-Control header and just send "Cache-Control: no-cache".

Also always send max-age header, since max-age=0 is OK to indicate no
caching should be done.

The problem was tested with 2.8.0 on rails 4.1.6, but the code hasn't changed.

After the fix the Cache-Control header will be either:

* `max-age=0, private, must-revalidate` for max_age 0
* `max-age=1, private, must-revalidate` for max_age 1 (default)
* `max-age=n, public, must-revalidate` for max_age n