### PR TITLE
Add log_level config setting which defaults to 'info'.

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -7,6 +7,10 @@ module HealthCheck
     cattr_accessor :routes_explicitly_defined 
   end
 
+  # Log level
+  mattr_accessor :log_level
+  self.log_level = 'info'
+
   # Text output upon success
   mattr_accessor :success
   self.success = "success"

--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -29,10 +29,9 @@ module HealthCheck
         else
           msg = HealthCheck.include_error_in_response_body ? "health_check failed: #{errors}" : nil
           send_response false, msg, HealthCheck.http_status_for_error_text, HealthCheck.http_status_for_error_object
+          
           # Log a single line as some uptime checkers only record that it failed, not the text returned
-          if logger
-            logger.info msg
-          end
+          logger.send(HealthCheck.log_level, msg) if logger
         end
       end
     end


### PR DESCRIPTION
This adds a config setting `log_level` which defaults to `info`, so the existing behavior is kept the same.

The log level can be set in a initializer like:
```ruby
HealthCheck.setup do |config|
  config.log_level = 'error'
end
```
