### PR TITLE
Use `remote_ip` to accept proxy-forwarded requests

### DIFF
--- a/lib/health_check/health_check_controller.rb
+++ b/lib/health_check/health_check_controller.rb
@@ -59,7 +59,7 @@ module HealthCheck
 
     def check_origin_ip
       unless HealthCheck.origin_ip_whitelist.blank? ||
-          HealthCheck.origin_ip_whitelist.include?(request.ip)
+          HealthCheck.origin_ip_whitelist.include?(request.remote_ip)
         render :plain => 'Health check is not allowed for the requesting IP',
                :status => HealthCheck.http_status_for_ip_whitelist_error,
                :content_type => 'text/plain'


### PR DESCRIPTION
If the service where this gem is installed is behind a proxy (e.g., Heroku router, Cloudflare) the `request.ip` will be the one of the proxy instead of the origin.

Good proxies (e.g., nginx) add the appropriate forwarding headers to the request to report the origin IP. Rails has the built in `request.remote_ip` method which appropriately parses the header (if present) to extract the origin IP.

Applying this small change will make the gem work out-of-the-box even in case of proxies.

I think it is the right thing to do but technically it also allows IP spoofing.