### PR TITLE
Support for redis password

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -145,6 +145,7 @@ To change the configuration of health_check, create a file `config/initializers/
 
       # When redis url is non-standard
       config.redis_url = 'redis_url'
+      config.redis_password = 'redis_password'
 
       # Disable the error message to prevent /health_check from leaking
       # sensitive information

--- a/health_check.gemspec
+++ b/health_check.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   	Simple health check of Rails app for uptime monitoring with Pingdom, NewRelic, EngineYard or uptime.openacs.org etc.
   EOF
   gem.homepage      = "https://github.com/ianheggie/health_check"
-  spec.license       = "MIT"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -4,7 +4,7 @@
 module HealthCheck
 
   class Engine < Rails::Engine
-    cattr_accessor :routes_explicitly_defined 
+    cattr_accessor :routes_explicitly_defined
   end
 
   # Text output upon success
@@ -67,9 +67,12 @@ module HealthCheck
 
   mattr_accessor :installed_as_middleware
 
-  # Allow non-standard redis url
+  # Allow non-standard redis url and password
   mattr_accessor :redis_url
   self.redis_url = nil
+
+  mattr_accessor :redis_password
+  self.redis_password = nil
 
   # Include the error in the response body. You may want to set this to false
   # if your /health_check endpoint is open to the public internet

--- a/lib/health_check/redis_health_check.rb
+++ b/lib/health_check/redis_health_check.rb
@@ -12,11 +12,11 @@ module HealthCheck
       rescue Exception => err
         create_error 'redis', err.message
       ensure
-        client.disconnect
+        client.close if client.connected?
       end
 
       def client
-        Redis.new(
+        @client ||= Redis.new(
           url: HealthCheck.redis_url,
           password: HealthCheck.redis_password
         )

--- a/lib/health_check/version.rb
+++ b/lib/health_check/version.rb
@@ -1,3 +1,3 @@
 module HealthCheck
-  VERSION = "4.0.0.pre"
+  VERSION = "4.0.1.pre"
 end


### PR DESCRIPTION
Added the support to connect with redis using a password, if none is provided it will behave as before.

Also, apply the [PR#88](https://github.com/ianheggie/health_check/pull/88) with a modification.

