### PR TITLE
Remove default password for redis

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -84,9 +84,9 @@ module HealthCheck
   self.redis_url = ENV['REDIS_URL']
 
   mattr_accessor :redis_password
-  self.redis_password = 'some-password'
+  self.redis_password = ENV['REDIS_PASSWORD']
 
-  # Include the error in the response body. 
+  # Include the error in the response body.
   # You should only do this where your /health_check endpoint is NOT open to the public internet
   mattr_accessor :include_error_in_response_body
   self.include_error_in_response_body = false


### PR DESCRIPTION
It seems, that there was an error when merging #103 to master in 6a4b72c3534483d311e373f64af6dcc6f9d870b5.

The current master 6cd2f91b522b7d4af16386f5a2e8f76300a8d6a2 (and the latest release) contains a default password for redis

https://github.com/ianheggie/health_check/blob/6cd2f91b522b7d4af16386f5a2e8f76300a8d6a2/lib/health_check.rb#L86-L87

while the original PR doesn't

https://github.com/ianheggie/health_check/pull/103/files#diff-1a44b837097f21eeaec4f487ab803a71df870ea355271e6e3838e81c8f614621R74-R75

This change makes our health checks fail (as we're not using password protection) with

```
[redis - ERR Client sent AUTH, but no password is set] 
```

I've fixed that in this PR and replaced `'redis_password'` with `ENV['REDIS_PASSWORD']` as this is also documented in the README.