### PR TITLE
add option to define if periods are wanted

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -95,6 +95,10 @@ module HealthCheck
   mattr_accessor :success_callbacks
   mattr_accessor :failure_callbacks
 
+  # define if you want the error messages to end with a period
+  mattr_accessor :do_not_add_period
+  self.do_not_add_period = false
+
   def self.add_custom_check(name = 'custom', &block)
     custom_checks[name] ||= [ ]
     custom_checks[name] << block

--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -90,7 +90,7 @@ module HealthCheck
               return "invalid argument to health_test."
             end
         end
-        errors << '. ' unless errors == '' || errors.end_with?('. ')
+        errors << '. ' unless errors == '' || errors.end_with?('. ') || HealthCheck.do_not_add_period
       end
       return errors.strip
     rescue => e


### PR DESCRIPTION
by default a period + space will be added at the end of the message.
if this behaviour isn't desired, it can now be turned off by defining   config.do_not_add_period = true

this would solve #113 