### PR TITLE
Use environment variable for configuring Redis password

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -84,7 +84,7 @@ module HealthCheck
   self.redis_url = ENV['REDIS_URL']
 
   mattr_accessor :redis_password
-  self.redis_password = 'some-password'
+  self.redis_password = ENV['REDIS_PASSWORD']
 
   # Include the error in the response body. 
   # You should only do this where your /health_check endpoint is NOT open to the public internet

--- a/lib/health_check/version.rb
+++ b/lib/health_check/version.rb
@@ -1,3 +1,3 @@
 module HealthCheck
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end


### PR DESCRIPTION
The existing documentation states
```
# When redis url/password is non-standard
config.redis_url = 'redis_url' # default ENV['REDIS_URL']
# Only included if set, as url can optionally include passwords as well
config.redis_password = 'redis_password' # default ENV['REDIS_PASSWORD']
```
Currently `config.redis_password` is hard-coded to the value `some-password` and can cause checks to fail (for instance in CI). 

Workaround until this change is accepted and merged
```ruby
config.redis_password = nil
```