### PR TITLE
Allow Elasticsearch to be configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Change Log =
 
+* HEAD
+  * Allow Elasticsearch to be configurable
+
 * 3.1.0 - 26 May 2021
   * Updated README to clarify railsN branch status (they are intended to be stable, development to be a feature branch off them or master)
   * Updated README with all the settings

--- a/README.rdoc
+++ b/README.rdoc
@@ -162,6 +162,9 @@ To change the configuration of health_check, create a file `config/initializers/
       # http status code used when the ip is not allowed for the request
       config.http_status_for_ip_whitelist_error = 403
 
+      # elasticsearch
+      config.elasticsearch_config = {}
+
       # rabbitmq
       config.rabbitmq_config = {}
 

--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -52,6 +52,10 @@ module HealthCheck
   mattr_accessor :buckets
   self.buckets = {}
 
+  # elasticsearch
+  mattr_accessor :elasticsearch_config
+  self.elasticsearch_config = {}
+
   # rabbitmq
   mattr_accessor :rabbitmq_config
   self.rabbitmq_config = {}

--- a/lib/health_check/elasticsearch_health_check.rb
+++ b/lib/health_check/elasticsearch_health_check.rb
@@ -6,7 +6,7 @@ module HealthCheck
       unless defined?(::Elasticsearch)
         raise "Wrong configuration. Missing 'elasticsearch' gem"
       end
-      res = ::Elasticsearch::Client.new.ping
+      res = ::Elasticsearch::Client.new(HealthCheck.elasticsearch_config).ping
       res == true ? '' : "Elasticsearch returned #{res.inspect} instead of true"
     rescue Exception => e
       create_error 'elasticsearch', e.message


### PR DESCRIPTION
Changes to allow a configuration hash to be passed to elasticsearch GEM.

```
Elasticsearch::Client.new(HealthCheck.elasticsearch_config)
```