### PR TITLE
Support Redis username

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -169,17 +169,19 @@ To change the configuration of health_check, create a file `config/initializers/
       config.redis_url = 'redis_url' # default ENV['REDIS_URL']
       # Only included if set, as url can optionally include passwords as well
       config.redis_password = 'redis_password' # default ENV['REDIS_PASSWORD']
+      # Only use if set, as url can optionally include username as well
+      config.redis_username = 'redis_username' # default ENV['REDIS_USERNAME']
 
       # Failure Hooks to do something more ...
       # checks lists the checks requested
       config.on_failure do |checks, msg|
         # log msg somewhere
       end
-    
+
       config.on_success do |checks|
         # flag that everything is well
       end
-  
+
 
     end
 

--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -79,12 +79,14 @@ module HealthCheck
 
   mattr_accessor :installed_as_middleware
 
-  # Allow non-standard redis url and password
+  # Allow non-standard redis url, password and username
   mattr_accessor :redis_url
   self.redis_url = ENV['REDIS_URL']
 
   mattr_accessor :redis_password
   self.redis_password = ENV['REDIS_PASSWORD']
+  mattr_accessor :redis_username
+  self.redis_username = ENV['REDIS_USERNAME']
 
   # Include the error in the response body.
   # You should only do this where your /health_check endpoint is NOT open to the public internet

--- a/lib/health_check/redis_health_check.rb
+++ b/lib/health_check/redis_health_check.rb
@@ -19,7 +19,8 @@ module HealthCheck
         @client ||= Redis.new(
           {
             url: HealthCheck.redis_url,
-            password: HealthCheck.redis_password
+            password: HealthCheck.redis_password,
+            username: HealthCheck.redis_username,
           }.reject { |k, v| v.nil? }
         )
       end


### PR DESCRIPTION
Redis ACLs feature that has been added in Redis 6.0 is allowed to specify a username and password.
https://redis.com/blog/getting-started-redis-6-access-control-lists-acls/

`redis` gem has supported this feature since https://github.com/redis/redis-rb/pull/967

This patch allows to specify `username` to the Redis client.