### PR TITLE
[Fix] Adjusting rails deprecated migration method to rails 7.2

### DIFF
--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -31,7 +31,14 @@ module HealthCheck
           when "emailconf"
             errors << HealthCheck::Utils.check_email if HealthCheck::Utils.mailer_configured?
           when "migrations", "migration"
-            if defined?(ActiveRecord::Migration) and ActiveRecord::Migration.respond_to?(:check_pending!)
+            if defined?(ActiveRecord::Migration) and ActiveRecord::Migration.respond_to?(:check_all_pending!)
+              # Rails 4+
+              begin
+                ActiveRecord::Migration.check_all_pending!
+              rescue ActiveRecord::PendingMigrationError => ex
+                  errors << ex.message
+              end
+            elsif defined?(ActiveRecord::Migration) and ActiveRecord::Migration.respond_to?(:check_pending!)
               # Rails 4+
               begin
                 ActiveRecord::Migration.check_pending!

--- a/lib/health_check/utils.rb
+++ b/lib/health_check/utils.rb
@@ -32,7 +32,7 @@ module HealthCheck
             errors << HealthCheck::Utils.check_email if HealthCheck::Utils.mailer_configured?
           when "migrations", "migration"
             if defined?(ActiveRecord::Migration) and ActiveRecord::Migration.respond_to?(:check_all_pending!)
-              # Rails 4+
+              # Rails 7.2+
               begin
                 ActiveRecord::Migration.check_all_pending!
               rescue ActiveRecord::PendingMigrationError => ex


### PR DESCRIPTION
### Context
Rails 7.2  removed the `deprecated check_pending!` method in favor of check_all_pending!

https://github.com/rails/rails/blob/0ad2334ae71e9a701f77887c8efd428a79a9c187/guides/source/7_2_release_notes.md?plain=1#L436

This PR adjust to include this new method validation in migrations checking.